### PR TITLE
Add link to context for forum

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,14 @@ var async = module.parent.require('async'),
 				tags = feed.tags.split(',');
 			}
 
-			var content = S(entry.summary.content).stripTags('div', 'script', 'span').trim().s;
+			var content = "";
+			try {
+			  content += S(entry.summary.content).stripTags('div', 'script', 'span').trim().s;
+			}
+			catch(e) {
+			  winston.warning('[[nodebb-plugin-rss:warning]] Summary is missing in '+ entry.link.href);
+			}
+			content += '<a href="'+entry.link.href+'"> Read more.. </a>';
 
 			if (settings.collapseWhiteSpace) {
 				content = S(content).collapseWhitespace().s;


### PR DESCRIPTION
This will help people to click through in the forum
to read the full article on the website.

This also patches the error caused when summary.content is missing.

```
modified:   index.js
```
